### PR TITLE
Added webots and webots_ros2 pkg installation to Dockerfile

### DIFF
--- a/andino_webots/LICENSE
+++ b/andino_webots/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2023, Ekumen Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/andino_webots/package.xml
+++ b/andino_webots/package.xml
@@ -4,7 +4,7 @@
   <name>andino_webots</name>
   <version>0.0.1</version>
   <description>Webots simulation of the Andino robot</description>
-  <maintainer email="ignacio.davila@@ekumenlabs.com">Ignacio Davila</maintainer>
+  <maintainer email="ignacio.davila@ekumenlabs.com">Ignacio Davila</maintainer>
   <maintainer email="franco.c@ekumenlabs.com">Franco Cipollone</maintainer>
   <maintainer email="christianbarcelo@ekumenlabs.com">Christian Barcelo</maintainer>
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,11 +14,33 @@ COPY docker/requirements.txt .
 RUN apt-get update && apt-get install --no-install-recommends -y $(cat requirements.txt)
 RUN rm requirements.txt
 
+# Install Webots
+RUN sudo wget -q https://cyberbotics.com/Cyberbotics.asc -O /etc/apt/keyrings/Cyberbotics.asc
+
+RUN echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/Cyberbotics.asc] https://cyberbotics.com/debian binary-amd64/" | sudo tee /etc/apt/sources.list.d/Cyberbotics.list
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y \
+    webots
+
+# TODO: Install package's specific version via rosdep
+# Install the 2023.1.1 release of webots_ros2
+ARG WEBOTS_ROS2_WS=/webots_ros2_ws
+RUN git clone --recurse-submodules --branch 2023.1.1 https://github.com/cyberbotics/webots_ros2.git ${WEBOTS_ROS2_WS}/src/webots_ros2
+
+RUN apt-get update && \
+    apt-get -y dist-upgrade && \
+    . /opt/ros/humble/setup.sh && \
+    rosdep install --from-paths ${WEBOTS_ROS2_WS}/src --ignore-src -r -y && \
+    colcon build --base-paths ${WEBOTS_ROS2_WS}/src/ --build-base ${WEBOTS_ROS2_WS}/build --install-base ${WEBOTS_ROS2_WS}/install && \
+    rm -rf /var/lib/apt/lists/*
+
 # Create a user with passwordless sudo
 RUN adduser --uid $USERID --gecos "ekumen developer" --disabled-password $USER
 RUN adduser $USER sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 RUN echo "export QT_X11_NO_MITSHM=1" >> /home/$USER/.bashrc
+RUN echo "source ${WEBOTS_ROS2_WS}/install/local_setup.bash" >> /home/$USER/.bashrc
 USER $USER
 
 # Adds USER to dialout and plugdev group.

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -22,4 +22,5 @@ python3-setuptools
 software-properties-common
 sudo
 tmux
+wget
 xterm


### PR DESCRIPTION
Added webots and the 2023.1.1 version for the `webots_ros2` package's installation to the Dockerfile. 

## Note to reviewers
The webots_ros2 package should be installed as a dependency of the `andino_webots` package.  Given that the version installed by default has problems spawning URDFs, the specified version should be installed using the [version attribute](https://www.ros.org/reps/rep-0140.html#build-depend-multiple) of the dependencies tag in the `package.xml`. However, when trying to install any version using this feature resulted in the default one. Added a `TODO` for this issue to be addressed in the future.

CC'ing @BarceloChristian 