### PR TITLE
Add teleoperation to andino in Webots

### DIFF
--- a/andino_webots/CMakeLists.txt
+++ b/andino_webots/CMakeLists.txt
@@ -24,6 +24,7 @@ find_package(ament_cmake REQUIRED)
 install(
   DIRECTORY
     launch
+    urdf
     worlds
     urdf
   DESTINATION

--- a/andino_webots/urdf/andino_webots.urdf
+++ b/andino_webots/urdf/andino_webots.urdf
@@ -17,5 +17,21 @@
                 <frameName>rplidar_laser_link</frameName>
             </ros>
         </device>
+
+        <plugin type="webots_ros2_control::Ros2Control" />
     </webots>
+
+    <ros2_control name="WebotsControl" type="system">
+        <hardware>
+            <plugin>webots_ros2_control::Ros2ControlSystem</plugin>
+        </hardware>
+        <joint name="right_wheel_joint">
+            <state_interface name="position"/>
+            <command_interface name="velocity"/>
+        </joint>
+        <joint name="left_wheel_joint">
+            <state_interface name="position"/>
+            <command_interface name="velocity"/>
+        </joint>
+    </ros2_control>
 </robot>


### PR DESCRIPTION
Adds the `webots_ros2_control` plugin to the `webotsController` urdf. This exposes the motors to ROS2 and creates an interface with the `ros2_control` pkg. 
Launches the `diff_drive_controller` and `joint_state_publisher` with the configuration provided in the `andino_control` package.

The webots motor device limits the velocity to 10 rad/s so the velocity in the controller configuration should be limited beforehand to avoid warning messages.

To test this feature just build and run the simulation. In another terminal send commands via `/cmd_vel`. To improve the steering the `RotationalMotor` from the caster wheel and base can be deleted from within the simulation.

CC @BarceloChristian 

https://github.com/ekumenlabs/andino_webots/assets/99193391/371b19a1-9661-42a4-ac95-48452fb162ff

