### PR TITLE
Spawn Andino on runtime

### DIFF
--- a/andino_webots/CMakeLists.txt
+++ b/andino_webots/CMakeLists.txt
@@ -26,7 +26,6 @@ install(
     launch
     urdf
     worlds
-    urdf
   DESTINATION
     share/${PROJECT_NAME}/
 )

--- a/andino_webots/launch/andino_webots.launch.py
+++ b/andino_webots/launch/andino_webots.launch.py
@@ -27,174 +27,71 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-import launch
 import os
 import xacro
 
 from ament_index_python.packages import get_package_share_directory
-from launch_ros.actions import Node
-from launch.actions import DeclareLaunchArgument
-from launch.conditions import IfCondition
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.substitutions import LaunchConfiguration
-from launch.substitutions.path_join_substitution import PathJoinSubstitution
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from webots_ros2_driver.urdf_spawner import URDFSpawner
-from webots_ros2_driver.webots_launcher import WebotsLauncher
-from webots_ros2_driver.webots_controller import WebotsController
-from webots_ros2_driver.wait_for_controller_connection import (
-    WaitForControllerConnection,
-)
-
-
-def configure_gazebo_sensors(robot_description: str):
-    """
-    Configures the lidar's near parameter and attaches the camera to a rotated frame so that
-    """
-    robot_description = robot_description.replace(
-        "</ray>",
-        """
-                <clip>
-                    <near>0.05</near>
-                </clip>
-            </ray>
-        """,
-    )
-    robot_description = robot_description.replace(
-        '<gazebo reference="camera_link">', '<gazebo reference="webots_camera_link">'
-    )
-    return robot_description
-
 
 # Obtain andino webots package
 andino_webots_pkg_dir = get_package_share_directory("andino_webots")
-andino_control_pkg_dir = get_package_share_directory("andino_control")
 
 
 def generate_launch_description():
-    andino_webots_description_xacro_path = os.path.join(
-        andino_webots_pkg_dir, "urdf", "andino_webots_description.urdf.xacro"
-    )
-    andino_webots_description = xacro.process_file(
-        andino_webots_description_xacro_path,
-        mappings={"use_gazebo_ros_control": "False", "use_fixed_caster": "False"},
-    ).toprettyxml(indent="    ")
-    andino_webots_description = configure_gazebo_sensors(andino_webots_description)
-
     world = LaunchConfiguration("world")
-    use_sim_time = LaunchConfiguration(
-        "use_sim_time", default=True
-    )  # Use the /clock topic to synchronize the ROS controller with the simulation
-    use_rsp = DeclareLaunchArgument("rsp", default_value="true")
+    rsp = LaunchConfiguration("rsp")
+    use_sim_time = LaunchConfiguration("use_sim_time")
+
+    use_rsp = DeclareLaunchArgument(
+        "rsp",
+        default_value="true",
+        description="Select whether to spawn the Robot State Publisher",
+    )
+    use_sim_time_arg = DeclareLaunchArgument(
+        "use_sim_time",
+        default_value="true",
+        description="Use the /clock topic to synchronize the ROS controller with the simulation",
+    )
     world_argument = DeclareLaunchArgument(
         "world",
-        default_value="andino_webots.wbt",
-    )
-    # The WebotsLauncher is used to start a Webots instance.
-    # Arguments:
-    # - `world` (str):              Path to the world to launch.
-    # - `gui` (bool):               Whether to display GUI or not.
-    # - `mode` (str):               Can be `pause`, `realtime`, or `fast`.
-    # - `ros2_supervisor` (bool):   Spawn the `Ros2Supervisor` custom node that communicates with a Supervisor robot in the simulation.
-    webots = WebotsLauncher(
-        world=PathJoinSubstitution([andino_webots_pkg_dir, "worlds", world]),
-        ros2_supervisor=True,
+        default_value="room.wbt",
+        description="Select world to spawn. Must be present in andino_webots/worlds",
     )
 
-    params = {"robot_description": andino_webots_description, "publish_frequency": 30.0}
-
-    # Robot state publisher
-    rsp = Node(
-        package="robot_state_publisher",
-        executable="robot_state_publisher",
-        namespace="",
-        output="both",
-        parameters=[params],
-        condition=IfCondition(LaunchConfiguration("rsp")),
+    # Includes andino_description launch file
+    include_webots_world = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                andino_webots_pkg_dir, "launch", "launch_webots_world.launch.py"
+            ),
+        ),
+        # Define what world will be spawning
+        launch_arguments={
+            "world": world,
+        }.items(),
     )
 
-    # webots_ros2 node to spawn robots from URDF
-    # TODO(#12): Update to PROTOSpawner when implementation is released
-    spawn_andino = URDFSpawner(
-        name="andino",
-        robot_description=andino_webots_description,
-        translation="0 0 0.022",
-        rotation=" 0 0 1 0",
-    )
-    # Webots Controller to initialize cameras/LIDARs and bridge ROS2
-    andino_webots_path = os.path.join(
-        andino_webots_pkg_dir, "urdf", "andino_webots.urdf"
-    )
-    ros2_control_params = os.path.join(
-        andino_control_pkg_dir, "config", "andino_controllers.yaml"
-    )
-    mappings = [
-        ("/diff_controller/cmd_vel_unstamped", "/cmd_vel"),
-        ("/diff_controller/odom", "/odom"),
-    ]
-    andino_webots_controller = WebotsController(
-        robot_name="andino",
-        parameters=[
-            {
-                "robot_description": andino_webots_path,
-                "use_sim_time": use_sim_time,
-            },
-            ros2_control_params,
-        ],
-        remappings=mappings,
-        respawn=True,
-    )
-
-    # ROS2 control
-    controller_manager_timeout = ["--controller-manager-timeout", "50"]
-    diffdrive_controller_spawner = Node(
-        package="controller_manager",
-        executable="spawner",
-        output="screen",
-        arguments=["diff_controller"] + controller_manager_timeout,
-        parameters=[
-            {"use_sim_time": use_sim_time},
-        ],
-    )
-    joint_state_broadcaster_spawner = Node(
-        package="controller_manager",
-        executable="spawner",
-        output="screen",
-        arguments=["joint_state_broadcaster"] + controller_manager_timeout,
-    )
-    ros_control_spawners = [
-        diffdrive_controller_spawner,
-        joint_state_broadcaster_spawner,
-    ]
-
-    # Wait for the simulation to be ready to start the diff drive and spawners
-    waiting_nodes = WaitForControllerConnection(
-        target_driver=andino_webots_controller, nodes_to_start=ros_control_spawners
+    include_spawn_andino = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                andino_webots_pkg_dir, "launch", "spawn_andino_webots.launch.py"
+            ),
+        ),
+        launch_arguments={
+            "rsp": rsp,
+            "use_sim_time": use_sim_time,
+        }.items(),
     )
 
     # Standard ROS 2 launch description
     return launch.LaunchDescription(
         [
-            # Set the world argument
-            world_argument,
-            # Start the Webots node
-            webots,
-            # Starts the Ros2Supervisor node created with the WebotsLauncher
-            webots._supervisor,
-            # Spawn Andino's URDF
-            spawn_andino,
-            # Add andino's controller
-            andino_webots_controller,
-            waiting_nodes,
-            # Robot state publisher
             use_rsp,
-            rsp,
-            # This action will kill all nodes once the Webots simulation has exited
-            launch.actions.RegisterEventHandler(
-                event_handler=launch.event_handlers.OnProcessExit(
-                    target_action=webots,
-                    on_exit=[launch.actions.EmitEvent(event=launch.events.Shutdown())],
-                )
-            ),
+            use_sim_time_arg,
+            world_argument,
+            include_webots_world,
+            include_spawn_andino,
         ]
     )

--- a/andino_webots/launch/launch_webots_world.launch.py
+++ b/andino_webots/launch/launch_webots_world.launch.py
@@ -1,0 +1,65 @@
+# BSD 3-Clause License
+
+# Copyright (c) 2023, Ekumen Inc.
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import launch
+from launch import LaunchDescription
+from launch.substitutions import LaunchConfiguration
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions.path_join_substitution import PathJoinSubstitution
+from ament_index_python.packages import get_package_share_directory
+from webots_ros2_driver.webots_launcher import WebotsLauncher
+
+
+def generate_launch_description():
+    andino_webots_pkg_dir = get_package_share_directory("andino_webots")
+    world = LaunchConfiguration("world")
+    world_arg = DeclareLaunchArgument(
+        "world",
+        default_value="room.wbt",
+        description="Choose one of the world files from `/andino_webots/worlds` directory",
+    )
+    webots = WebotsLauncher(
+        world=PathJoinSubstitution([andino_webots_pkg_dir, "worlds", world]),
+        ros2_supervisor=True,
+    )
+
+    return LaunchDescription(
+        [
+            world_arg,
+            webots,
+            webots._supervisor,
+            # This action will kill all nodes once the Webots simulation has exited
+            launch.actions.RegisterEventHandler(
+                event_handler=launch.event_handlers.OnProcessExit(
+                    target_action=webots,
+                    on_exit=[launch.actions.EmitEvent(event=launch.events.Shutdown())],
+                )
+            ),
+        ]
+    )

--- a/andino_webots/launch/spawn_andino_webots.launch.py
+++ b/andino_webots/launch/spawn_andino_webots.launch.py
@@ -1,0 +1,201 @@
+# BSD 3-Clause License
+
+# Copyright (c) 2023, Ekumen Inc.
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import os
+import pathlib
+import launch
+import xacro
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.conditions import IfCondition
+from launch_ros.actions import Node
+from launch.substitutions import LaunchConfiguration
+from ament_index_python.packages import get_package_share_directory
+from webots_ros2_driver.urdf_spawner import URDFSpawner, get_webots_driver_node
+from webots_ros2_driver.webots_controller import WebotsController
+from webots_ros2_driver.wait_for_controller_connection import (
+    WaitForControllerConnection,
+)
+
+
+def configure_gazebo_sensors(robot_description: str):
+    """
+    Configures the lidar's near parameter and attaches the camera to a rotated frame so that
+    """
+    robot_description = robot_description.replace(
+        "</ray>",
+        """
+                    <clip>
+                        <near>0.05</near>
+                    </clip>
+                </ray>
+        """,
+    )
+    robot_description = robot_description.replace(
+        '<gazebo reference="camera_link">', '<gazebo reference="webots_camera_link">'
+    )
+    return robot_description
+
+
+andino_webots_pkg_dir = get_package_share_directory("andino_webots")
+andino_control_pkg_dir = get_package_share_directory("andino_control")
+
+
+def generate_launch_description():
+    use_sim_time = LaunchConfiguration("use_sim_time")
+
+    use_rsp = DeclareLaunchArgument(
+        "rsp",
+        default_value="true",
+        description="Select whether to spawn the Robot State Publisher",
+    )
+    use_sim_time_arg = DeclareLaunchArgument(
+        "use_sim_time",
+        default_value="true",
+    )
+
+    andino_gazebo_xacro_path = os.path.join(
+        andino_webots_pkg_dir, "urdf", "andino_webots_description.urdf.xacro"
+    )
+    andino_gazebo_description = xacro.process_file(
+        andino_gazebo_xacro_path,
+        mappings={"use_gazebo_ros_control": "False", "use_fixed_caster": "False"},
+    ).toprettyxml(indent="    ")
+    andino_gazebo_description = configure_gazebo_sensors(andino_gazebo_description)
+
+    # TODO(#12): Update to PROTOSpawner when implementation is released
+    spawn_andino = URDFSpawner(
+        name="andino",
+        robot_description=andino_gazebo_description,
+        translation="0 0 0.022",
+        rotation=" 0 0 1 0",
+    )
+
+    # Robot state publisher
+    params = {"robot_description": andino_gazebo_description, "publish_frequency": 30.0}
+    rsp = Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        namespace="",
+        output="both",
+        parameters=[params],
+        condition=IfCondition(LaunchConfiguration("rsp")),
+    )
+
+    andino_robot_driver = Node(
+        package="webots_ros2_driver",
+        executable="driver",
+        output="screen",
+        additional_env={"WEBOTS_CONTROLLER_URL": "Andino Webots"},
+        parameters=[
+            {"robot_description": andino_gazebo_description},
+        ],
+    )
+    # Webots Controller to initialize cameras/LIDARs
+    andino_webots_path = os.path.join(
+        andino_webots_pkg_dir, "urdf", "andino_webots.urdf"
+    )
+    ros2_control_params = os.path.join(
+        andino_control_pkg_dir, "config", "andino_controllers.yaml"
+    )
+    mappings = [
+        ("/diff_controller/cmd_vel_unstamped", "/cmd_vel"),
+        ("/diff_controller/odom", "/odom"),
+    ]
+
+    andino_webots_controller = WebotsController(
+        robot_name="andino",
+        parameters=[
+            {
+                "robot_description": andino_webots_path,
+                "use_sim_time": use_sim_time,
+            },
+            ros2_control_params,
+        ],
+        remappings=mappings,
+        respawn=True,
+    )
+
+    # ROS2 control
+    controller_manager_timeout = ["--controller-manager-timeout", "5000"]
+    diffdrive_controller_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        output="screen",
+        arguments=["diff_controller"] + controller_manager_timeout,
+        parameters=[
+            {"use_sim_time": use_sim_time},
+        ],
+    )
+    joint_state_broadcaster_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        output="screen",
+        arguments=["joint_state_broadcaster"] + controller_manager_timeout,
+    )
+    ros_control_spawners = [
+        diffdrive_controller_spawner,
+        joint_state_broadcaster_spawner,
+    ]
+
+    # Wait for the simulation to be ready to start the diff drive and spawners
+    waiting_nodes = WaitForControllerConnection(
+        target_driver=andino_webots_controller, nodes_to_start=ros_control_spawners
+    )
+
+    return LaunchDescription(
+        [
+            use_sim_time_arg,
+            # Request to spawn the Andino via URDF
+            spawn_andino,
+            # Add andino's controller
+            andino_webots_controller,
+            waiting_nodes,
+            # Robot state publisher
+            use_rsp,
+            rsp,
+            # Launch the driver node once the URDF robot is spawned
+            launch.actions.RegisterEventHandler(
+                event_handler=launch.event_handlers.OnProcessIO(
+                    target_action=spawn_andino,
+                    on_stdout=lambda event: get_webots_driver_node(
+                        event, andino_robot_driver
+                    ),
+                )
+            ),
+            # Kill all the nodes when the driver node is shut down (useful with other ROS 2 nodes)
+            launch.actions.RegisterEventHandler(
+                event_handler=launch.event_handlers.OnProcessExit(
+                    target_action=andino_robot_driver,
+                    on_exit=[launch.actions.EmitEvent(event=launch.events.Shutdown())],
+                )
+            ),
+        ]
+    )

--- a/andino_webots/worlds/room.wbt
+++ b/andino_webots/worlds/room.wbt
@@ -1,0 +1,126 @@
+#VRML_SIM R2023b utf8
+
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023b/projects/objects/backgrounds/protos/TexturedBackground.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023b/projects/objects/lights/protos/CeilingLight.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023b/projects/objects/lights/protos/FloorLight.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023b/projects/objects/apartment_structure/protos/Wall.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023b/projects/objects/apartment_structure/protos/Door.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023b/projects/objects/bedroom/protos/Bed.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023b/projects/objects/tables/protos/Table.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023b/projects/objects/chairs/protos/Chair.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023b/projects/objects/living_room_furniture/protos/Armchair.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023b/projects/objects/paintings/protos/LandscapePainting.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023b/projects/appearances/protos/Parquetry.proto"
+
+WorldInfo {
+  info [
+    "Andino simulation"
+  ]
+  title "Andino demo"
+  contactProperties [
+    ContactProperties {
+      material2 "andino_caster"
+        coulombFriction [
+          0
+        ]
+    }
+  ]
+}
+Viewpoint {
+  orientation -0.36262744823728477 0.27598686583446086 0.8901306553937948 1.8872003649958273
+  position 3.5997682605906762 -18.55541804553904 20.130291618268966
+  near 0.1
+}
+TexturedBackground {
+}
+CeilingLight {
+  translation 1.82639 -1.29685 2.4
+  pointLightColor 1 1 0.9372549019607843
+  pointLightIntensity 7
+}
+CeilingLight {
+  translation -3.25511 1.9443400000000004 2.4
+  name "ceiling light(2)"
+  pointLightIntensity 6
+}
+FloorLight {
+  translation -4.528276895458201 -4.2693419342918375 0
+  pointLightIntensity 2
+}
+Wall {
+  translation 5 0 0
+  size 0.3 10.3 2.4
+}
+Wall {
+  translation 0 5 0
+  rotation 0 0 1 1.5708
+  name "wall(2)"
+  size 0.3 9.7 2.4
+}
+Wall {
+  translation -5 0 0
+  name "wall(3)"
+  size 0.3 10.3 2.4
+}
+Wall {
+  translation 0 -5 0
+  rotation 0 0 1 1.5708
+  name "wall(4)"
+  size 0.3 9.7 2.4
+}
+Wall {
+  translation -1.65 2.675 0
+  name "wall(5)"
+  size 0.3 4.35 2.4
+}
+Wall {
+  translation -1.65 -1.15 0
+  name "wall(6)"
+  size 0.3 1.3 2.4
+}
+Door {
+  translation -1.65 0 0
+  size 0.3 1 2.4
+}
+Bed {
+  translation 3.75 3.2800000002397445 0
+  rotation 0 0 1 3.1415
+}
+Table {
+  translation -3.28632 -3.86254 0
+}
+Chair {
+  translation -3.72164 -3.47751 0
+  rotation 0 0 -1 -0.11945530717958608
+}
+Table {
+  translation 2.2745 -0.476732 0
+  rotation 0 0 1 0.534482
+  name "table(2)"
+  size 0.8 1.2 0.53
+}
+Armchair {
+  translation 3.5894 0.323101 0
+  rotation 0 0 1 -2.5895153071795862
+}
+LandscapePainting {
+  translation 0.292736 -4.77308 1.5
+  rotation 0 0 1 1.5708
+}
+Solid {
+  children [
+    Shape {
+      appearance Parquetry {
+        textureTransform TextureTransform {
+          scale 7 7
+        }
+      }
+      geometry Plane {
+        size 10 10
+      }
+    }
+  ]
+  boundingObject Plane {
+    size 9.9 9.9
+  }
+}


### PR DESCRIPTION
This PR separates the launchfile into two different files, one for starting the simulation and spawning an empty world, and another  to spawn an Andino in a currently running simulation.
A third launchfile is kept to include both files in order to be able to spawn a world with Andino with a single command. This launchfiles keeps the arguments received by the main launchfile present in previous versions of the package.

Additionally added a second `.wbt` world file which is set as default.

Cc'ing @BarceloChristian 