### PR TITLE
Add webots_ros2 as dependency

### DIFF
--- a/andino_webots/package.xml
+++ b/andino_webots/package.xml
@@ -15,8 +15,8 @@
   <exec_depend>andino_description</exec_depend>
   <exec_depend>andino_gz_classic</exec_depend>
   <exec_depend>node_remover_plugin</exec_depend>
-  <exec_depend>xacro</exec_depend>
   <exec_depend>webots_ros2</exec_depend>
+  <exec_depend>xacro</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
 
 RUN apt-get update && \
     apt-get -y dist-upgrade && \
-    . /opt/ros/humble/setup.sh && \
     rm -rf /var/lib/apt/lists/*
 
 # Create a user with passwordless sudo


### PR DESCRIPTION
# 🦟 Bug fix

Fixes [#33](https://github.com/ekumenlabs/andino_webots/issues/33#issue-1926268705)

## Summary
During development the `webots_ros2` package installed by rosdep brought some issues when importing URDF. After a review this is no longer the case and we can set the package as a ros dependency.

To test this change, rebuild the image (without the package installation), run `rosdep install --from-paths src -i -y` and corroborate Andino gets spawned into the simulation.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
